### PR TITLE
readme: add glm to list of dependencies

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ Make sure you have all the relevant dependencies installed:
 - OpenGL
 - Glew
 - Physfs
+- [glm](https://glm.g-truc.net/)
 
 ## Contributions:
 


### PR DESCRIPTION
Without the GLM dependency, I got the following error when building Front_and_Flame:

```
u@x220 ~/D/F/build> time make
Scanning dependencies of target frost_and_flame
[  2%] Building CXX object CMakeFiles/frost_and_flame.dir/source/main.cpp.o
In file included from /home/u/Desktop/Frost_and_Flame/source/game/../RoboEngine/roboengine.hpp:28:0,
                 from /home/u/Desktop/Frost_and_Flame/source/game/mainloop.hpp:28,
                 from /home/u/Desktop/Frost_and_Flame/source/main.cpp:24:
/home/u/Desktop/Frost_and_Flame/source/game/../RoboEngine/core/re_common_headers.hpp:45:14: fatal error: glm/glm.hpp: No such file or directory
     #include <glm/glm.hpp>
              ^~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/frost_and_flame.dir/build.make:63: CMakeFiles/frost_and_flame.dir/source/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:68: CMakeFiles/frost_and_flame.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
Command exited with non-zero status 2
real 0.31
user 0.19
sys 0.05
```